### PR TITLE
タイトルをフロント側から翻訳するようにした

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "scripts": {
-    "dev": "NODE_ENV=development parcel ./src/**/*.html",
+    "dev": "NODE_ENV=development parcel --no-hmr ./src/**/*.html",
     "build": "NODE_ENV=production parcel build ./src/**/*.html"
   },
   "dependencies": {

--- a/src/scripts/main.ts
+++ b/src/scripts/main.ts
@@ -64,7 +64,6 @@ const appendPapers = (papers: Paper[]): void => {
     figureImgElement.classList.add("paper--content--left--figures--img");
 
     titleElement.textContent = paper.title;
-    jaTitleElement.textContent = "(" + papers[idx].title_ja + ")";
 
     // Elementにテキストを挿入
     if (papers[idx].authors != null) {
@@ -76,6 +75,7 @@ const appendPapers = (papers: Paper[]): void => {
     keywordsElement.textContent = "keyword1";
     citeElement.textContent = "cite：" + papers[idx].cite_count;
     citedElement.textContent = "cited：" + papers[idx].cited_count;
+    jaTitleElement.textContent = paper.title_ja || "(和訳しています……)";
     linkElement.setAttribute("href", paper.url);
     linkElement.setAttribute("target", "_blank");
     linkElement.textContent = paper.url;
@@ -114,6 +114,20 @@ const appendPapers = (papers: Paper[]): void => {
     // bodyにpaper elementを挿入
     if (mainElement === null) return;
     mainElement.appendChild(paperElement);
+
+    if (!paper.title_ja)
+      axios
+        .get(`${railsHost}/translate`, {
+          params: {
+            paper: paper.id,
+            type: "title",
+            text: paper.title
+          }
+        })
+        .then(response => {
+          jaTitleElement.textContent = "(" + response.data.text + ")";
+          return response;
+        });
   });
 };
 

--- a/src/scripts/main.ts
+++ b/src/scripts/main.ts
@@ -80,7 +80,7 @@ const appendPapers = (papers: Paper[]): void => {
     linkElement.setAttribute("target", "_blank");
     linkElement.textContent = paper.url;
     dateElement.textContent = format(
-      new Date(paper.created_at),
+      new Date(paper.published_at),
       "yyyy年MM月dd日"
     );
 

--- a/src/scripts/models/index.ts
+++ b/src/scripts/models/index.ts
@@ -52,6 +52,7 @@ export interface Figure {
 }
 
 export interface Paper {
+  id: string;
   abstract: string;
   title: string;
   title_ja: string;

--- a/src/scripts/models/index.ts
+++ b/src/scripts/models/index.ts
@@ -57,9 +57,7 @@ export interface Paper {
   title: string;
   title_ja: string;
   abstract_ja: string;
-  journal: string;
   authors: Author[];
-  published_at: string;
   keywords: Keyword[];
   url: string;
   pdf_url: string;


### PR DESCRIPTION
## Feature
- **フロント側から翻訳APIを叩くようにした。流れは以下の通り。**
1. 日本語訳が空の場合、Railsから英語のデータを取得する
1. フロントから翻訳APIをRails経由で叩く
1. Railsは翻訳結果をフロントに返すと同時にDBに翻訳結果を保存する

## Fixed
完全に別件だが別PR立てるの面倒だったので(クソ)
- 論文の公開日時(`published_at`)が正しく表示されるようにした
    - 今まではRailsのデータベースに登録された日時(`created_at`)が表示されていた
- TypeScriptの型定義が雑だった部分をリファクタリングした
    - プロパティが重複している部分があった

## Update
- 開発時、変更を保存した瞬間にブラウザがリロードされるのをOFFにした
    - 保存するたびに翻訳APIを叩かれると枠を使い果たして死ぬため

## Note
- 直接翻訳APIを叩かずRailsを経由する理由は以下の2点。
    - 翻訳APIはGAS(Google Apps Script)で組んだが、これがCORS(フロントから、フロントと異なるドメインにアクセスを許可する設定)を設定できなかったため、ブラウザから直接APIを叩くことができなかった。
    - Railsを経由することで翻訳結果を1リクエストで保存&取得できるため。