### PR TITLE
画像周りのレイアウトを修正する

### DIFF
--- a/src/paper.html
+++ b/src/paper.html
@@ -34,17 +34,14 @@
   <div id="figure-modal" class="modal--wrapper">
     <div class="modal--overlay" id="modal-overlay"></div>
     <div class="modal--window" id="modal-window">
-      <!-- <div class="modal--content">
-        <img class="modal--img">
-        <p class="modal--text__en"></p>
-        <p class="modal--text__ja"></p>
-      </div> -->
+      <div class="modal--content-wrapper" id="modal-content-wrapper"></div>
       <div class="modal--close" id="modal-close">✕</div>
     </div>
   </div>
 
   <!-- モーダルテンプレート -->
   <template id="modal-template">
+    <div class="modal--control__prev">&lt;</div>
     <div class="modal--content">
       <a class="modal--img-link" target="_blank">
         <img class="modal--img">
@@ -57,6 +54,7 @@
       <p class="modal--text__en"></p>
       <p class="modal--text__ja active"></p>
     </div>
+    <div class="modal--control__next">&gt;</div>
   </template>
 
   <!-- 論文テンプレート -->

--- a/src/paper.html
+++ b/src/paper.html
@@ -46,7 +46,10 @@
   <!-- モーダルテンプレート -->
   <template id="modal-template">
     <div class="modal--content">
-      <img class="modal--img">
+      <a class="modal--img-link" target="_blank">
+        <img class="modal--img">
+      </a>
+      <p class="modal--img-click-caption">画像をクリックすると別タブで開きます</p>
       <div class="switches">
         <div class="switch__to-ja">日本語</div>
         <div class="switch__to-en active">英語</div>

--- a/src/scripts/paper.ts
+++ b/src/scripts/paper.ts
@@ -81,7 +81,7 @@ const appendPapers = (paper: Paper): void => {
       imgWrapperElement.addEventListener("click", async () => {
         const modalTemplate = document.getElementById("modal-template") as HTMLTemplateElement;
         const modalElement = document.getElementById("figure-modal") as HTMLDivElement;
-        const modalWindowElement = modalElement.querySelector(".modal--window") as HTMLDivElement;
+        const modalContentWrapperElement = modalElement.querySelector(".modal--content-wrapper") as HTMLDivElement;
         const modalContentElement = document.importNode(modalTemplate.content, true);
         const modalImgElement = modalContentElement.querySelector(".modal--img") as HTMLImageElement;
         const modalImgLinkElement = modalContentElement.querySelector(".modal--img-link") as HTMLAnchorElement;
@@ -89,6 +89,8 @@ const appendPapers = (paper: Paper): void => {
         const modalTextJaElement = modalContentElement.querySelector(".modal--text__ja") as HTMLParagraphElement;
         const switchToJaElement = modalContentElement.querySelector(".switch__to-ja") as HTMLDivElement;
         const switchToEnElement = modalContentElement.querySelector(".switch__to-en") as HTMLDivElement;
+        const nextButtonElement = modalContentElement.querySelector(".modal--control__next") as HTMLDivElement;
+        const prevButtonElement = modalContentElement.querySelector(".modal--control__prev") as HTMLDivElement;
 
         // 言語切替ボタンの挙動
         switchToEnElement.addEventListener("click", () => {
@@ -104,7 +106,17 @@ const appendPapers = (paper: Paper): void => {
           modalTextJaElement.classList.add("active");
         });
 
-        modalWindowElement.textContent = null;
+        // 前後ボタン
+        if (imgWrapperElement.nextElementSibling === null) nextButtonElement.style.visibility = "hidden";
+        if (imgWrapperElement.previousElementSibling === null) prevButtonElement.style.visibility = "hidden";
+        nextButtonElement.addEventListener("click", () => {
+          (imgWrapperElement.nextElementSibling as HTMLElement).click();
+        });
+        prevButtonElement.addEventListener("click", () => {
+          (imgWrapperElement.previousElementSibling as HTMLElement).click();
+        });
+
+        modalContentWrapperElement.textContent = null;
 
         // 画像を入れ込む
         modalImgElement.src = figure.figure.url;
@@ -116,7 +128,7 @@ const appendPapers = (paper: Paper): void => {
           modalTextJaElement.textContent = figure.caption_ja || "翻訳中です…";
         }
 
-        modalWindowElement.appendChild(modalContentElement);
+        modalContentWrapperElement.appendChild(modalContentElement);
 
         // モーダルのアクティブ化
         modalElement.classList.add("active");

--- a/src/scripts/paper.ts
+++ b/src/scripts/paper.ts
@@ -84,6 +84,7 @@ const appendPapers = (paper: Paper): void => {
         const modalWindowElement = modalElement.querySelector(".modal--window") as HTMLDivElement;
         const modalContentElement = document.importNode(modalTemplate.content, true);
         const modalImgElement = modalContentElement.querySelector(".modal--img") as HTMLImageElement;
+        const modalImgLinkElement = modalContentElement.querySelector(".modal--img-link") as HTMLAnchorElement;
         const modalTextElement = modalContentElement.querySelector(".modal--text__en") as HTMLParagraphElement;
         const modalTextJaElement = modalContentElement.querySelector(".modal--text__ja") as HTMLParagraphElement;
         const switchToJaElement = modalContentElement.querySelector(".switch__to-ja") as HTMLDivElement;
@@ -107,6 +108,7 @@ const appendPapers = (paper: Paper): void => {
 
         // 画像を入れ込む
         modalImgElement.src = figure.figure.url;
+        modalImgLinkElement.href = figure.figure.url;
 
         // 画像の説明を入れ込む
         modalTextElement.textContent = figure.caption || figure.explanation || "";

--- a/src/styles/paper.scss
+++ b/src/styles/paper.scss
@@ -51,13 +51,14 @@
 
   &--figures {
     display: none;
-    border: 1px solid;
-    padding: $base-space $base-space 0;
     margin-bottom: $base-space-2;
     margin-top: $base-space;
 
     &.active {
       display: flex;
+      flex-direction: row;
+      flex-wrap: wrap;
+      justify-content: center;
     }
 
     &__analyzing,
@@ -70,12 +71,18 @@
     }
   }
 
+  &--figure-wrapper {
+    width: 100px;
+    height: 100px;
+    padding: 5px;
+    margin: -0.5px;
+    border: 1px solid $base-color-2;
+  }
+
   &--figure {
     width: 100%;
-    height: 100px;
-    object-fit: cover;
-    margin-right: $base-space;
-    margin-bottom: $base-space;
+    height: 100%;
+    object-fit: contain;
   }
 
   &--abstract {

--- a/src/styles/paper.scss
+++ b/src/styles/paper.scss
@@ -259,11 +259,16 @@
     position: relative;
     width: 85%;
     max-width: 600px;
-    padding: 30px 30px 15px;
+    padding: 30px 0 15px;
     border-radius: 2px;
     background: #fff;
     box-shadow: 0 0 30px rgba(0, 0, 0, 0.6);
     vertical-align: middle;
+  }
+
+  &--content-wrapper {
+    display: flex;
+    justify-items: center;
   }
 
   &--content {
@@ -303,11 +308,10 @@
     cursor: pointer;
   }
 
-  &--close {
+  &--close,
+  &--control__prev,
+  &--control__next {
     z-index: 20;
-    position: absolute;
-    top: 0;
-    right: 0;
     width: 35px;
     color: #95979c !important;
     font-size: 20px;
@@ -317,6 +321,18 @@
     text-decoration: none;
     text-indent: 0;
     cursor: pointer;
+  }
+
+  &--close {
+    position: absolute;
+    top: 0;
+    right: 0;
+  }
+
+  &--control__prev,
+  &--control__next {
+    font-size: 30px;
+    margin: auto 15px;
   }
 
   &--close:hover {

--- a/src/styles/paper.scss
+++ b/src/styles/paper.scss
@@ -103,6 +103,7 @@
     font-weight: bolder;
     margin: 0;
     display: inline-block;
+    margin-right: $base-space-2;
   }
 }
 
@@ -117,7 +118,6 @@
     color: white;
     border: 1px solid $base-color;
     border-radius: 5px;
-    margin-left: $base-space-2;
     margin-top: $base-space;
     cursor: pointer;
     display: inline-block;
@@ -126,6 +126,10 @@
       background-color: white;
       color: $base-color;
     }
+  }
+
+  &__to-en {
+    margin-left: $base-space-2;
   }
 }
 
@@ -260,6 +264,11 @@
     overflow-y: auto;
   }
 
+  &--img-click-caption {
+    font-size: 0.5rem;
+    margin: 0;
+  }
+
   &--text {
     &__en,
     &__ja {
@@ -269,6 +278,11 @@
         display: block;
       }
     }
+  }
+
+  &--img {
+    max-width: 100%;
+    max-height: 50vh;
   }
 
   &--overlay {


### PR DESCRIPTION
## Features ✨ 
- 画像めくり機能を追加

## Fixed 🔧 
- 画像がたくさんあると見づらい問題を修正
- 画像が大きい場合に縦横スクロールが必要になる問題を修正

## Notes 📝 
- 画像一覧がこれで良いかどうか使ってみて考えたい。アコーディオンにしようかとも思ったけど、一覧性が落ちるのでとりあえずタイルレイアウトにしてみた。

## ScreenShots 📱 
### 画像めくり機能
![画像めくり機能](https://user-images.githubusercontent.com/6907421/72870014-4abc5a00-3d2a-11ea-9907-0acc2204cf4c.png)

### 画像一覧
![画像一覧](https://user-images.githubusercontent.com/6907421/72869963-25c7e700-3d2a-11ea-8a13-53a4c7b17046.png)

