### PR TITLE
issue/41 英語タイトルのフォントサイズを調整

### DIFF
--- a/src/styles/paper.scss
+++ b/src/styles/paper.scss
@@ -21,7 +21,7 @@
 
   &--title {
     &__en {
-      font-size: $font-size-l;
+      font-size: $font-size-m;
       margin-bottom: $base-space;
     }
 

--- a/src/styles/papers.scss
+++ b/src/styles/papers.scss
@@ -3,7 +3,6 @@
 
 // 論文リストのアイテム(1論文)
 .paper {
-  margin: 1rem auto;
   padding: 1rem;
   border-bottom: 1px solid black;
   display: block;
@@ -20,7 +19,8 @@
     margin-bottom: $base-space-2;
 
     &__en {
-      font-size: $font-size-m;
+      font-size: $font-size-sm;
+      margin-bottom: $base-space;
     }
 
     &__ja {


### PR DESCRIPTION
【変更点】
・英語タイトルのフォントサイズを小さくしました
・検索結果画面の不要なmarginを削除しました
・境目がわかりにくかったので英語タイトルと日本語タイトルの間にmarginを付けました