### PR TITLE
入力されたクエリを検索結果に表示する

### DIFF
--- a/src/papers.html
+++ b/src/papers.html
@@ -46,20 +46,14 @@
 
     <template id="paper-template">
       <a class="paper">
-        <div class="paper--title">
-          <div class="paper--title__en"></div>
-          <div class="paper--title__ja"></div>
+        <div class="paper--date"></div>
+        <div class="paper--figure-wrapper">
+          <img class="paper--figure" />
         </div>
-        <div class="paper--content">
-          <div class="paper--content__left">
-            <div class="paper--figure-wrapper">
-              <img class="paper--figure" />
-            </div>
-          </div>
-          <div class="paper--content__right">
-            <div class="paper--authors"></div>
-            <div class="paper--date"></div>
-          </div>
+        <div class="paper--authors"></div>
+        <div class="paper--title">
+          <div class="paper--title__ja"></div>
+          <div class="paper--title__en"></div>
         </div>
       </a>
     </template>

--- a/src/scripts/papers.ts
+++ b/src/scripts/papers.ts
@@ -39,7 +39,6 @@ searchResultElement.appendChild(queryTextElement);
 
 const appendPapers = (papers: Paper[]): void => {
   const mainElement = document.getElementById("main");
-  console.log(papers.length);
 
   if (papers.length < 30) {
     // 検索結果30件未満の場合は「さらに読む」ボタンを表示しない
@@ -71,17 +70,26 @@ const appendPapers = (papers: Paper[]): void => {
 
     paperAnchorElement.setAttribute("href", `/paper.html?id=${paper.id}`);
 
-    titleElement.textContent = paper.title;
+    titleElement.textContent = "(" + paper.title + ")";
 
     // Elementにテキストを挿入
     if (papers[idx].authors !== undefined) {
-      for (let i = 0; i < papers[idx].authors.length; i++) {
-        authorsElement.textContent = "Author：" + papers[idx].authors[i].name;
+      let authorLength = 1;
+      for (const author of papers[idx].authors) {
+        const authorElement = document.createElement("span");
+        authorElement.classList.add("paper--authors__name");
+        if (authorLength === papers[idx].authors.length) {
+          authorElement.textContent = author.name;
+        } else {
+          authorElement.textContent = author.name + ",";
+        }
+        authorsElement.appendChild(authorElement);
+        authorLength += 1;
       }
     }
 
     jaTitleElement.textContent = paper.title_ja || "(和訳しています……)";
-    dateElement.textContent = format(new Date(paper.published_at), "yyyy年MM月dd日");
+    dateElement.textContent = format(new Date(paper.published_at), "yyyy-MM-dd");
 
     if (papers[idx].figures.length > 0) {
       figureImgElement.setAttribute("src", papers[idx].figures[0].figure.url);

--- a/src/scripts/papers.ts
+++ b/src/scripts/papers.ts
@@ -39,6 +39,22 @@ searchResultElement.appendChild(queryTextElement);
 
 const appendPapers = (papers: Paper[]): void => {
   const mainElement = document.getElementById("main");
+  console.log(papers.length);
+
+  if (papers.length < 30) {
+    // 検索結果30件未満の場合は「さらに読む」ボタンを表示しない
+    const getMoreElement = document.getElementById("next-button")!;
+    getMoreElement.style.display = "none";
+  }
+
+  if (papers.length === 0) {
+    // 検索結果0件の場合はその旨を表示する
+    const noResultElement = document.createElement("p");
+    noResultElement.classList.add("no-result");
+    noResultElement.textContent = "お探しの論文は見つかりませんでした。キーワードが日本語の場合は英語で入力してください。";
+    if (mainElement === null) return;
+    mainElement.appendChild(noResultElement);
+  }
 
   papers.forEach((paper, idx) => {
     if (paperTemplate === null) return;

--- a/src/scripts/papers.ts
+++ b/src/scripts/papers.ts
@@ -29,13 +29,21 @@ const paperNameRaw = parser.searchParams.get("name");
 let currentPage = 0;
 let paperTemplate: HTMLTemplateElement | null = null;
 
+// 検索クエリの表示
+const searchResultElement = document.createElement("div");
+const queryTextElement = document.createElement("p");
+searchResultElement.classList.add("search-result");
+queryTextElement.classList.add("search-result--query");
+queryTextElement.textContent = paperNameRaw + " の検索結果";
+searchResultElement.appendChild(queryTextElement);
+
 const appendPapers = (papers: Paper[]): void => {
   const mainElement = document.getElementById("main");
 
   papers.forEach((paper, idx) => {
     if (paperTemplate === null) return;
 
-    // Elementを生成
+    // Elementを作成
     const paperElement = document.importNode(paperTemplate.content, true);
 
     const paperAnchorElement = paperElement.querySelector(".paper")!;
@@ -71,7 +79,8 @@ const appendPapers = (papers: Paper[]): void => {
 
     // bodyにpaper elementを挿入
     if (mainElement === null) return;
-    mainElement.appendChild(paperElement);
+    mainElement.appendChild(searchResultElement);
+    searchResultElement.appendChild(paperElement);
 
     if (!paper.title_ja)
       axios

--- a/src/styles/papers.scss
+++ b/src/styles/papers.scss
@@ -1,6 +1,17 @@
 @import "variables";
 @import "global.scss";
 
+//検索クエリの表示
+.search-result {
+  &--query {
+    margin: $base-space-2 $base-space 0;
+    border: 1px solid black;
+    padding: $base-space;
+    font-size: $font-size-s;
+    border-radius: 4px;
+  }
+}
+
 // 論文リストのアイテム(1論文)
 .paper {
   padding: 1rem;

--- a/src/styles/papers.scss
+++ b/src/styles/papers.scss
@@ -6,6 +6,7 @@
   @media screen and (min-width: 500px) {
     display: flex;
     flex-wrap: wrap;
+    justify-content: center;
   }
   &--query {
     margin: $base-space-2 $base-space 0;

--- a/src/styles/papers.scss
+++ b/src/styles/papers.scss
@@ -35,6 +35,10 @@
     width: 250px;
   }
 
+  @media screen and (max-width: 600px) {
+    border-bottom: 1px solid $base-color;
+  }
+
   // iPad
   @media screen and (max-width: 780px) and (min-width: 750px) {
     width: 224px;
@@ -62,12 +66,23 @@
     }
   }
 
+  &--figure-wrapper {
+    border: 1px solid $base-color;
+    border-radius: 4px;
+    margin-bottom: $base-space;
+  }
+
   &--figure {
     display: block;
     max-width: 100%;
-    max-height: 100%;
+    height: 160px;
     object-fit: cover;
     margin-right: $base-space;
+    margin: 0 auto;
+
+    @media screen and (max-width: 600px) {
+      height: 200px;
+    }
 
     &__no-img {
       @media screen and (max-width: 600px) {
@@ -75,7 +90,6 @@
         height: 200px;
         object-fit: cover;
         margin-right: $base-space;
-        margin-bottom: $base-space;
       }
 
       @media screen and (min-width: 500px) {
@@ -83,7 +97,6 @@
         height: 160px;
         object-fit: cover;
         margin-right: $base-space;
-        margin-bottom: $base-space;
       }
     }
   }

--- a/src/styles/papers.scss
+++ b/src/styles/papers.scss
@@ -12,6 +12,11 @@
   }
 }
 
+.no-result {
+  margin: $base-space-3;
+  font-size: $font-size-s;
+}
+
 // 論文リストのアイテム(1論文)
 .paper {
   padding: 1rem;

--- a/src/styles/papers.scss
+++ b/src/styles/papers.scss
@@ -3,12 +3,20 @@
 
 //検索クエリの表示
 .search-result {
+  @media screen and (min-width: 500px) {
+    display: flex;
+    flex-wrap: wrap;
+  }
   &--query {
     margin: $base-space-2 $base-space 0;
     border: 1px solid black;
     padding: $base-space;
     font-size: $font-size-s;
     border-radius: 4px;
+
+    @media screen and (min-width: 500px) {
+      width: 808px;
+    }
   }
 }
 
@@ -20,10 +28,17 @@
 // 論文リストのアイテム(1論文)
 .paper {
   padding: 1rem;
-  border-bottom: 1px solid black;
   display: block;
-  color: black;
   text-decoration: none;
+
+  @media screen and (min-width: 500px) {
+    width: 250px;
+  }
+
+  // iPad
+  @media screen and (max-width: 780px) and (min-width: 750px) {
+    width: 224px;
+  }
 
   &:first-child {
     border-top: 1px solid black;
@@ -32,30 +47,18 @@
   &--title {
     font-weight: bolder;
     color: $base-blue;
-    margin-bottom: $base-space-2;
+    margin-bottom: $base-space;
+    @media screen and (max-width: 600px) {
+      margin-bottom: 0px;
+    }
 
     &__en {
-      font-size: $font-size-sm;
-      margin-bottom: $base-space;
+      font-size: $font-size-ss;
     }
 
     &__ja {
       font-size: $font-size-s;
-    }
-  }
-
-  &--content {
-    display: flex;
-
-    &__left {
-      width: 50%;
-    }
-
-    &__right {
-      width: 50%;
-      margin-bottom: $base-space-2;
-      margin-top: $base-space;
-      margin-left: $base-space-2;
+      margin-bottom: $base-space;
     }
   }
 
@@ -65,12 +68,11 @@
     max-height: 100%;
     object-fit: cover;
     margin-right: $base-space;
-    margin-bottom: $base-space;
 
     &__no-img {
       @media screen and (max-width: 600px) {
         width: 100%;
-        height: 100px;
+        height: 200px;
         object-fit: cover;
         margin-right: $base-space;
         margin-bottom: $base-space;
@@ -78,7 +80,7 @@
 
       @media screen and (min-width: 500px) {
         width: 100%;
-        height: 200px;
+        height: 160px;
         object-fit: cover;
         margin-right: $base-space;
         margin-bottom: $base-space;
@@ -87,16 +89,23 @@
   }
 
   &--authors {
-    font-size: $font-size-s;
+    color: $base-color;
+    margin-bottom: $base-space;
+
+    &__name {
+      font-size: $font-size-ss;
+    }
   }
 
   &--date {
     font-size: $font-size-s;
+    margin-bottom: $base-space;
+    color: $base-color;
   }
 }
 
 main {
-  max-width: 798px;
+  max-width: 860px;
   margin: auto;
 }
 

--- a/src/styles/variables.scss
+++ b/src/styles/variables.scss
@@ -1,6 +1,7 @@
 @import url("https://fonts.googleapis.com/css?family=Noto+Sans+JP:400,900&display=swap&subset=japanese");
 
 //フォントサイズ
+$font-size-sss: 0.6rem;
 $font-size-ss: 0.8rem;
 $font-size-s: 1rem;
 $font-size-sm: 1.2rem;


### PR DESCRIPTION
issue/72 に加えてissue/40, issue/77も対応

【変更点】
issue/72
・入力されたクエリを検索結果上部に表示した
issue/40
・検索結果が0件の時、「お探しの論文は見つかりませんでした。キーワードが日本語の場合は英語で入力してください。」の文言表示
・検索結果が30件未満の時、「さらに読み込む」ボタンを表示しない
issue/77
・検索結果画面のUIを変更（PCの場合論文カセットが3つ横に並ぶ）
・検索結果画面の著者が全員表示されるようになった
・画像の高さを一律に統一した