### PR TITLE
titleとdescriptionを動的に変化するように実装

### DIFF
--- a/src/paper.html
+++ b/src/paper.html
@@ -8,6 +8,11 @@
       name="description"
       content="CatchAppは、あなたが読みたい論文をサクサク探すためのサイトです。"
     />
+    <meta
+      property="og:description"
+      content="CatchAppは、あなたが読みたい論文をサクサク探すためのサイトです。"
+    />
+    <meta property="og:title" content="CatchApp" />
     <title>CatchApp</title>
     <script src="./scripts/paper.ts"></script>
     <link rel="stylesheet" href="./styles/paper.scss" />

--- a/src/papers.html
+++ b/src/papers.html
@@ -8,6 +8,11 @@
       name="description"
       content="CatchAppは、あなたが読みたい論文をサクサク探すためのサイトです。"
     />
+    <meta
+      property="og:description"
+      content="CatchAppは、あなたが読みたい論文をサクサク探すためのサイトです。"
+    />
+    <meta property="og:title" content="CatchApp" />
     <title>CatchApp</title>
     <script src="./scripts/papers.ts"></script>
     <script src="../node_modules/@webcomponents/template/template.min.js"></script>

--- a/src/scripts/paper.ts
+++ b/src/scripts/paper.ts
@@ -19,6 +19,10 @@ const appendPapers = (paper: Paper): void => {
   document.title = paper.title;
   document.querySelector("meta[name='description']")!.setAttribute("content", paper.title_ja);
 
+  // ogpタグの設定
+  document.querySelector("meta[property='og:title']")!.setAttribute("content", paper.title);
+  document.querySelector("meta[property='og:description']")!.setAttribute("content", paper.title_ja);
+
   if (paper === undefined) return;
 
   const appElement = document.getElementById("app")!;

--- a/src/scripts/paper.ts
+++ b/src/scripts/paper.ts
@@ -15,7 +15,9 @@ const appendPapers = (paper: Paper): void => {
   if (paperIdRaw === null) return;
   if (paperTemplate === null) return;
 
-  console.log(paper);
+  // titleとdescriptionの設定
+  document.title = paper.title;
+  document.querySelector("meta[name='description']")!.setAttribute("content", paper.title_ja);
 
   if (paper === undefined) return;
 

--- a/src/scripts/paper.ts
+++ b/src/scripts/paper.ts
@@ -16,11 +16,11 @@ const appendPapers = (paper: Paper): void => {
   if (paperTemplate === null) return;
 
   // titleとdescriptionの設定
-  document.title = paper.title;
+  document.title = paper.title + " | CatchApp";
   document.querySelector("meta[name='description']")!.setAttribute("content", paper.title_ja);
 
   // ogpタグの設定
-  document.querySelector("meta[property='og:title']")!.setAttribute("content", paper.title);
+  document.querySelector("meta[property='og:title']")!.setAttribute("content", paper.title + " | CatchApp");
   document.querySelector("meta[property='og:description']")!.setAttribute("content", paper.title_ja);
 
   if (paper === undefined) return;
@@ -52,7 +52,7 @@ const appendPapers = (paper: Paper): void => {
   jaTitleElement.textContent = paper.title_ja;
   journalElement.textContent = paper.journal || "ジャーナルを取得できませんでした";
   dateElement.textContent = "published: " + format(new Date(paper.published_at), "yyyy-MM-dd");
-  shareElement.setAttribute("data-text", paper.title + "\n(" + paper.title_ja + ")\n");
+  shareElement.setAttribute("data-text", paper.title_ja + "\n(" + paper.title + ")\n");
 
   abstractEnElement.textContent = paper.abstract;
   abstractJaElement.textContent = paper.abstract_ja || "翻訳中……";

--- a/src/scripts/papers.ts
+++ b/src/scripts/papers.ts
@@ -41,6 +41,12 @@ const appendPapers = (papers: Paper[]): void => {
       .querySelector("meta[name='description']")!
       .setAttribute("content", paperNameRaw + " の検索結果 \n CatchAppで「" + paperNameRaw + "」に関する論文をサクサク見つけよう。");
 
+    // ogpタグの設定
+    document.querySelector("meta[property='og:title']")!.setAttribute("content", paperNameRaw + " の検索結果 | CatchApp");
+    document
+      .querySelector("meta[property='og:description']")!
+      .setAttribute("content", paperNameRaw + " の検索結果 \n CatchAppで「" + paperNameRaw + "」に関する論文をサクサク見つけよう。");
+
     // Elementを生成
     const paperElement = document.importNode(paperTemplate.content, true);
 

--- a/src/scripts/papers.ts
+++ b/src/scripts/papers.ts
@@ -35,6 +35,12 @@ const appendPapers = (papers: Paper[]): void => {
   papers.forEach((paper, idx) => {
     if (paperTemplate === null) return;
 
+    // titleとdescriptionの設定
+    document.title = paperNameRaw + " の検索結果 | CatchApp";
+    document
+      .querySelector("meta[name='description']")!
+      .setAttribute("content", paperNameRaw + " の検索結果 \n CatchAppで「" + paperNameRaw + "」に関する論文をサクサク見つけよう。");
+
     // Elementを生成
     const paperElement = document.importNode(paperTemplate.content, true);
 


### PR DESCRIPTION
【変更点】
titleとdescriptionを動的に変化するように実装

# 検索結果画面
title: [入力されたクエリ] の検索結果 | CatchApp
description: [入力されたクエリ] の検索結果 CatchAppで[入力されたクエリ] に関する論文をサクサク見つけよう。

# 論文詳細画面
title: [論文英語タイトル]
description:[論文日本語タイトル]