### PR TITLE
新着論文にバッチを付ける、表示される著者を3人までに制限

### DIFF
--- a/src/papers.html
+++ b/src/papers.html
@@ -51,7 +51,10 @@
 
     <template id="paper-template">
       <a class="paper">
-        <div class="paper--date"></div>
+        <div class="paper--info">
+          <div class="paper--info__date"></div>
+          <div class="paper--info__badge"></div>
+        </div>
         <div class="paper--figure-wrapper">
           <img class="paper--figure" />
         </div>

--- a/src/scripts/papers.ts
+++ b/src/scripts/papers.ts
@@ -17,7 +17,7 @@
 
 import axios from "axios";
 import { Paper } from "./models";
-import { format } from "date-fns";
+import { format, formatDistanceToNow } from "date-fns";
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const images = require("../image/*.png");
@@ -77,20 +77,40 @@ const appendPapers = (papers: Paper[]): void => {
     const titleElement = paperElement.querySelector(".paper--title__en")!;
     const jaTitleElement = paperElement.querySelector(".paper--title__ja")!;
     const authorsElement = paperElement.querySelector(".paper--authors")!;
-    const dateElement = paperElement.querySelector(".paper--date")!;
+    const dateElement = paperElement.querySelector(".paper--info__date")!;
+    const badgeElement = paperElement.querySelector(".paper--info__badge")!;
     const figureImgElement = paperElement.querySelector(".paper--figure")!;
 
     paperAnchorElement.setAttribute("href", `/paper.html?id=${paper.id}`);
 
     titleElement.textContent = "(" + paper.title + ")";
 
+    // 新着論文にバッジを付ける
+    // 1週間前の日付
+    const beforeAWeek = new Date();
+    beforeAWeek.setDate(beforeAWeek.getDate() - 7);
+    const pubDate = new Date(paper.published_at);
+    // 1週間以内にpublishされた論文にバッジを付ける
+    if (pubDate > beforeAWeek) {
+      badgeElement.textContent = "NEW!";
+      badgeElement.classList.add("paper--info__badge-active");
+    }
+
     // Elementにテキストを挿入
     if (papers[idx].authors !== undefined) {
       let authorLength = 1;
+
+      // 著者を複数人表示する
       for (const author of papers[idx].authors) {
         const authorElement = document.createElement("span");
         authorElement.classList.add("paper--authors__name");
-        if (authorLength === papers[idx].authors.length) {
+
+        // 著者が4人以上の場合は4人目以下を切り捨て
+        if (papers[idx].authors.length >= 4 && authorLength === 3) {
+          authorElement.textContent = author.name + "ほか";
+        } else if (papers[idx].authors.length >= 4 && authorLength === 4) {
+          break;
+        } else if (authorLength === papers[idx].authors.length) {
           authorElement.textContent = author.name;
         } else {
           authorElement.textContent = author.name + ",";

--- a/src/scripts/papers.ts
+++ b/src/scripts/papers.ts
@@ -17,7 +17,7 @@
 
 import axios from "axios";
 import { Paper } from "./models";
-import { format, formatDistanceToNow } from "date-fns";
+import { format } from "date-fns";
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const images = require("../image/*.png");

--- a/src/scripts/papers.ts
+++ b/src/scripts/papers.ts
@@ -86,19 +86,19 @@ const appendPapers = (papers: Paper[]): void => {
     titleElement.textContent = "(" + paper.title + ")";
 
     // 新着論文にバッジを付ける
-    // 1週間前の日付
+    // 1日前の日付
     const beforeAWeek = new Date();
-    beforeAWeek.setDate(beforeAWeek.getDate() - 7);
+    beforeAWeek.setDate(beforeAWeek.getDate() - 2);
     const pubDate = new Date(paper.published_at);
-    // 1週間以内にpublishされた論文にバッジを付ける
-    if (pubDate > beforeAWeek) {
+    // 1日以内にpublishされた論文にバッジを付ける
+    if (pubDate >= beforeAWeek) {
       badgeElement.textContent = "NEW!";
       badgeElement.classList.add("paper--info__badge-active");
     }
 
     // Elementにテキストを挿入
     if (papers[idx].authors !== undefined) {
-      let authorLength = 1;
+      let authorNumber = 1;
 
       // 著者を複数人表示する
       for (const author of papers[idx].authors) {
@@ -106,17 +106,19 @@ const appendPapers = (papers: Paper[]): void => {
         authorElement.classList.add("paper--authors__name");
 
         // 著者が4人以上の場合は4人目以下を切り捨て
-        if (papers[idx].authors.length >= 4 && authorLength === 3) {
+        if (papers[idx].authors.length >= 4 && authorNumber === 3) {
           authorElement.textContent = author.name + "ほか";
-        } else if (papers[idx].authors.length >= 4 && authorLength === 4) {
+          authorsElement.appendChild(authorElement);
           break;
-        } else if (authorLength === papers[idx].authors.length) {
+        } else if (authorNumber === papers[idx].authors.length) {
           authorElement.textContent = author.name;
+          authorsElement.appendChild(authorElement);
         } else {
           authorElement.textContent = author.name + ",";
+          authorsElement.appendChild(authorElement);
         }
-        authorsElement.appendChild(authorElement);
-        authorLength += 1;
+
+        authorNumber += 1;
       }
     }
 

--- a/src/styles/papers.scss
+++ b/src/styles/papers.scss
@@ -111,10 +111,26 @@
     }
   }
 
-  &--date {
-    font-size: $font-size-s;
+  &--info {
+    display: flex;
     margin-bottom: $base-space;
-    color: $base-color;
+
+    &__date {
+      font-size: $font-size-s;
+      color: $base-color;
+      width: 85%;
+    }
+
+    &__badge-active {
+      font-size: $font-size-ss;
+      font-weight: bold;
+      padding: 4px;
+      border-radius: 4px;
+      color: white;
+      background-color: $badge-color;
+      text-align: center;
+      width: 50px;
+    }
   }
 }
 

--- a/src/styles/variables.scss
+++ b/src/styles/variables.scss
@@ -24,6 +24,7 @@ $base-blue: #2a6fb6;
 $base-blue-2: #203377;
 $base-color: #979292; //灰色
 $base-color-2: #4d5254; //濃い灰色
+$badge-color: #ffd700;
 
 * {
   font-family: "Noto Sans JP", sans-serif;


### PR DESCRIPTION
【変更点】
・1週間以内にpublishされた論文に「NEW!」バッチを付与する
・検索結果画面に表示される著者を3人までに制限し、4人以上の場合は「ほか」をつける

<img width="1152" alt="スクリーンショット 2020-02-09 18 15 41" src="https://user-images.githubusercontent.com/49139795/74099535-379dec80-4b68-11ea-9fec-2d974457245e.png">
